### PR TITLE
Use newer base distribution in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,18 @@
 language: clojure
+dist: focal
 jdk:
-  - openjdk8
   - openjdk11
 env:
   global:
   - POSTGRESQL_DB_HOST=localhost
-  - POSTGRESQL_DB_PORT=5433
+  - POSTGRESQL_DB_PORT=5432
   - POSTGRESQL_DB_USERNAME=postgres
   - POSTGRESQL_DB_PASSWORD=
-  - PGPORT=5433
-services:
-  - postgresql
 addons:
   postgresql: "12"
   apt:
     packages:
-    - postgresql-12
-    - postgresql-client-12
+      - postgresql-12
 before_install:
   # Hack needed to have working authententication with the postgres user
   - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/12/main/pg_hba.conf


### PR DESCRIPTION
Use latest Ubuntu LTS 20.04.

Also drop JDK 8 as there is some error with its installation.