### PR TITLE
Remove unreliable UT case

### DIFF
--- a/test/env_logger/weather_test.clj
+++ b/test/env_logger/weather_test.clj
@@ -134,16 +134,7 @@
       (is (nil? (-update-fmi-weather-data-json 87874))))
     (with-redefs [j/read-value (fn [_ _]
                                  {:observations nil})]
-      (is (nil? (-update-fmi-weather-data-json 87874))))
-    (with-redefs [j/read-value (fn [_ _]
-                                 {:observations
-                                  [{:localtime "20221228T221000"
-                                    :WindDirection 70
-                                    :WindSpeedMS 2.8
-                                    :TotalCloudCover 7
-                                    :t2m -7.1
-                                    :localtz "Europe/Helsinki"}]})]
-      (is (not (nil? (-update-fmi-weather-data-json 87874)))))))
+      (is (nil? (-update-fmi-weather-data-json 87874))))))
 
 (deftest fmi-weather-data-fetch
   (testing "Tests FMI weather data fetch"


### PR DESCRIPTION
In addition to being unreliable he value of this case is questionable as it does not properly check the return value.