### PR TITLE
backend: fix some datetime handling problems

### DIFF
--- a/src/env_logger/electricity.clj
+++ b/src/env_logger/electricity.clj
@@ -43,19 +43,20 @@
               (serve-json {:data-hour (db/get-elec-data-hour con
                                                              start-date
                                                              nil)
-                           :data-day (db/get-elec-data-day con start-date nil)
+                           :data-day (db/get-elec-data-day
+                                      con
+                                      (db/add-tz-offset-to-dt start-date)
+                                      nil)
                            :dates {:current {:start
-                                             (t/format
-                                              (t/formatter
-                                               :iso-local-date)
-                                              (if (= (:display-timezone
-                                                      env) "UTC")
-                                                (t/plus start-date
-                                                        (t/hours
-                                                         (db/get-tz-offset
-                                                          (:store-timezone
-                                                           env))))
-                                                start-date))}
+                                             (t/format :iso-local-date
+                                                       (if (= (:display-timezone
+                                                               env) "UTC")
+                                                         (t/plus start-date
+                                                                 (t/hours
+                                                                  (db/get-tz-offset
+                                                                   (:store-timezone
+                                                                    env))))
+                                                         start-date))}
                                    :max (db/get-elec-price-interval-end con)
                                    :min (db/get-elec-consumption-interval-start
                                          con)}}))))))))

--- a/src/env_logger/handler.clj
+++ b/src/env_logger/handler.clj
@@ -121,7 +121,7 @@
                      ruuvitag-locations))
          :obs-dates {:current {:start
                                (when (:end obs-dates)
-                                 (t/format (t/formatter :iso-local-date)
+                                 (t/format :iso-local-date
                                            (t/minus (t/local-date
                                                      (t/formatter
                                                       :iso-local-date)

--- a/test/env_logger/db_test.clj
+++ b/test/env_logger/db_test.clj
@@ -34,6 +34,7 @@
                                    insert-tb-image-name
                                    insert-wd
                                    make-local-dt
+                                   add-tz-offset-to-dt
                                    test-db-connection
                                    validate-date]])
   (:import (org.postgresql.util PSQLException
@@ -69,9 +70,9 @@
 
 ;; Current datetime used in tests
 (def current-dt (t/local-date-time))
-(def current-dt-zoned (t/format (t/formatter :iso-offset-date-time)
+(def current-dt-zoned (t/format :iso-offset-date-time
                                 (t/zoned-date-time)))
-(def date-fmt (t/formatter :iso-local-date))
+(def date-fmt :iso-local-date)
 
 (defn clean-test-database
   "Cleans the test database before and after running tests. Also inserts one
@@ -248,6 +249,11 @@
            (str (make-local-dt "2020-09-27" "start"))))
     (is (= "2020-09-27T23:59:59"
            (str (make-local-dt "2020-09-27" "end"))))))
+
+(deftest test-add-tz-offset-to-dt
+  (testing "TZ offset adding"
+    (let [orig-dt (t/local-date-time)]
+      (is (= orig-dt (add-tz-offset-to-dt orig-dt))))))
 
 (deftest weather-obs-interval-select
   (testing "Select weather observations between one or two dates"


### PR DESCRIPTION
Also:
* Add a new function to remove the need for copypasting
* Remove redundant (t/formatter) calls